### PR TITLE
Fix test error and warning for mbed

### DIFF
--- a/examples/mbed-examples/test_driver/test_Performance/test_Performance.c
+++ b/examples/mbed-examples/test_driver/test_Performance/test_Performance.c
@@ -1,4 +1,5 @@
-#include<string.h>
+#include <stdio.h>
+#include <string.h>
 #include "cmsis.h"
 #include "gap_performance.h"
 
@@ -12,7 +13,7 @@ int main()
 
     PERFORMANCE_Stop(&perf);
 
-    printf("Total CYCLE : %d\n" , PERFORMANCE_Get(&perf, PCER_CYCLE_Pos));
-    printf("Total INSTR : %d\n" , PERFORMANCE_Get(&perf, PCER_INSTR_Pos));
+    printf("Total CYCLE : %d\n" , (int)PERFORMANCE_Get(&perf, PCER_CYCLE_Pos));
+    printf("Total INSTR : %d\n" , (int)PERFORMANCE_Get(&perf, PCER_INSTR_Pos));
     return 0;
 }


### PR DESCRIPTION
- Update cluster UART printf, use delegate function number to call FC
- Fix hyperbus address alignement 16 bits -> 8 bits for file system
- Optimisation for UDAM asynchronous hardware request queue 
- Add hyperbus C++ api header in mbed.h