### PR TITLE
Updated location of version log for gap_flasher

### DIFF
--- a/tools/version/record_version.sh
+++ b/tools/version/record_version.sh
@@ -52,7 +52,7 @@ record_version $GAP_SDK_HOME/examples/pulp-examples;
 record_version $GAP_SDK_HOME/tf2gap8;
 
 # Flasher version
-record_version $GAP_SDK_HOME/tools/gap_flasher
+record_version $GAP_SDK_HOME/tools/pulp_tools/gap_flasher
 
 # Application version
 record_version $GAP_SDK_HOME/applications;


### PR DESCRIPTION
Minor update that resolves this update: https://github.com/GreenWaves-Technologies/gap_sdk/commit/d5d010a4e0be6f0539d87c4daf50af3d69d63e94