### PR TITLE
Reduce hyperram size, maximum transfer size is 1024 BYTE only in 133MHz

### DIFF
--- a/examples/mbed-examples/test_driver/test_HYPER_RAM/test_HYPER_RAM.c
+++ b/examples/mbed-examples/test_driver/test_HYPER_RAM/test_HYPER_RAM.c
@@ -3,7 +3,7 @@
 // HYPERBUS CMSIS driver
 #include "hyperbus_api.h"
 
-#define BUFFER_SIZE       1024
+#define BUFFER_SIZE       512
 #define CONF_REG_DEFAULT  0x8F1F
 #define RXTX_ADDR         0x800
 


### PR DESCRIPTION
Fix  hyperram test's buffer size,