### PR TITLE
Fix build of camera-related applications and examples

### DIFF
--- a/applications/BilinearResize/ImgIO.c
+++ b/applications/BilinearResize/ImgIO.c
@@ -298,7 +298,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
 
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-#define CHUNK_NUM 10
     int File = BRIDGE_Open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
     int ret = 0;
     WritePPMHeader(File,W,H);

--- a/applications/BilinearResize/test_resize.c
+++ b/applications/BilinearResize/test_resize.c
@@ -166,26 +166,26 @@ static int32_t open_camera_himax(struct pi_device *device)
 
 static int32_t open_camera_mt9v034(struct pi_device *device)
 {
-    struct mt9v034_conf cam_conf;
+    struct pi_mt9v034_conf cam_conf;
 
-    mt9v034_conf_init(&cam_conf);
-    cam_conf.format = CAMERA_QVGA;
+    pi_mt9v034_conf_init(&cam_conf);
+    cam_conf.format = PI_CAMERA_QVGA;
     pi_open_from_conf(device, &cam_conf);
-    if (camera_open(device))
+    if (pi_camera_open(device))
     {
         return -1;
     }
     uint16_t val = MT9V034_BLACK_LEVEL_AUTO;
-    camera_reg_set(device, MT9V034_BLACK_LEVEL_CTRL, &val);
+    pi_camera_reg_set(device, MT9V034_BLACK_LEVEL_CTRL, &val);
     val = MT9V034_AEC_ENABLE_A|MT9V034_AGC_ENABLE_A;
-    camera_reg_set(device, MT9V034_AEC_AGC_ENABLE, &val);
+    pi_camera_reg_set(device, MT9V034_AEC_AGC_ENABLE, &val);
 
     //max exposure def:0x01E0
     val = 0x0FE0;
-    camera_reg_set(device, 0xAD, &val);
+    pi_camera_reg_set(device, 0xAD, &val);
     //Max Analog Gain def: 0x0040
     val = 0x0F40;
-    camera_reg_set(device, 0xAB, &val);
+    pi_camera_reg_set(device, 0xAB, &val);
 
     return 0;
 }

--- a/applications/CannyEdgeDetection/ImgIO.c
+++ b/applications/CannyEdgeDetection/ImgIO.c
@@ -217,7 +217,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = rt_bridge_open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/applications/FaceDetection/main.c
+++ b/applications/FaceDetection/main.c
@@ -35,9 +35,6 @@
 #define LCD_WIDTH    320
 #define LCD_HEIGHT   240
 
-//#define DEBUG_PRINTF(...)
-#define DEBUG_PRINTF printf
-
 static unsigned char *imgBuff0;
 static struct pi_device ili;
 static pi_buffer_t buffer;
@@ -99,7 +96,7 @@ static int open_camera_mt9v034(struct pi_device *device)
   struct pi_mt9v034_conf cam_conf;
 
   pi_mt9v034_conf_init(&cam_conf);
-  cam_conf.format = CAMERA_QVGA;
+  cam_conf.format = PI_CAMERA_QVGA;
 
   pi_open_from_conf(device, &cam_conf);
   if (pi_camera_open(device))

--- a/applications/MultiScalePedestrianDetector/ImgIO.c
+++ b/applications/MultiScalePedestrianDetector/ImgIO.c
@@ -216,7 +216,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = rt_bridge_open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/applications/WaterMeter/ImgIO.c
+++ b/applications/WaterMeter/ImgIO.c
@@ -216,7 +216,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = rt_bridge_open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/autotiler/BilinearResize/ImgIO.c
+++ b/examples/autotiler/BilinearResize/ImgIO.c
@@ -298,7 +298,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
 
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-#define CHUNK_NUM 10
     int File = BRIDGE_Open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
     int ret = 0;
     WritePPMHeader(File,W,H);

--- a/examples/autotiler/HoG/ImgIO.c
+++ b/examples/autotiler/HoG/ImgIO.c
@@ -216,7 +216,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = rt_bridge_open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/autotiler/IntegralImage/ImgIO.c
+++ b/examples/autotiler/IntegralImage/ImgIO.c
@@ -216,7 +216,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = rt_bridge_open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/autotiler/Mnist/ImgIO.c
+++ b/examples/autotiler/Mnist/ImgIO.c
@@ -297,7 +297,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
 
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-#define CHUNK_NUM 10
     int File = BRIDGE_Open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
     int ret = 0;
     WritePPMHeader(File,W,H);

--- a/examples/native/mbed-gapoc/GAPOC_BSP/GAPOC_BSP_GENERAL/GAPOC_BSP_ImgIO.c
+++ b/examples/native/mbed-gapoc/GAPOC_BSP/GAPOC_BSP_GENERAL/GAPOC_BSP_ImgIO.c
@@ -223,7 +223,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = BRIDGE_Open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/native/mbed/test_bsp/GAPUINO_HIMAX/ImgIO.c
+++ b/examples/native/mbed/test_bsp/GAPUINO_HIMAX/ImgIO.c
@@ -222,7 +222,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = BRIDGE_Open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/native/mbed/test_driver_gap8/test_Bridge_Image/ImgIO.c
+++ b/examples/native/mbed/test_driver_gap8/test_Bridge_Image/ImgIO.c
@@ -222,7 +222,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = BRIDGE_Open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/native/pulpos/kernel/bridge/image_io/ImgIO.c
+++ b/examples/native/pulpos/kernel/bridge/image_io/ImgIO.c
@@ -216,7 +216,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = rt_bridge_open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/native/pulpos/periph/camera/camera_HIMAX_IO/ImgIO.c
+++ b/examples/native/pulpos/periph/camera/camera_HIMAX_IO/ImgIO.c
@@ -216,7 +216,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = rt_bridge_open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/native/pulpos/periph/camera/camera_HIMAX_slice/ImgIO.c
+++ b/examples/native/pulpos/periph/camera/camera_HIMAX_slice/ImgIO.c
@@ -216,7 +216,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = rt_bridge_open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/examples/nntool/mnist/ImgIO.c
+++ b/examples/nntool/mnist/ImgIO.c
@@ -249,7 +249,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
 
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = __OPEN(ImageName, O_RDWR | O_CREAT, S_IRWXU);
 	int ret = 0;
 	WritePPMHeader(File, W, H);

--- a/examples/pmsis/test_periph/test_camera_lcd/test_camera_lcd.c
+++ b/examples/pmsis/test_periph/test_camera_lcd/test_camera_lcd.c
@@ -78,7 +78,7 @@ static int32_t open_display(struct pi_device *device)
         printf("Failed to open display\n");
         return -1;
     }
-    //display_ioctl(device, ILI_IOCTL_ORIENTATION, (void *) ILI_ORIENTATION_270);
+    //pi_display_ioctl(device, PI_ILI_IOCTL_ORIENTATION, (void *) PI_ILI_ORIENTATION_270);
     return 0;
 }
 #endif  /* HAVE_DISPLAY */
@@ -109,12 +109,12 @@ static int32_t open_camera_himax(struct pi_device *device)
 
 static int32_t open_camera_mt9v034(struct pi_device *device)
 {
-    struct mt9v034_conf cam_conf;
+    struct pi_mt9v034_conf cam_conf;
     pi_mt9v034_conf_init(&cam_conf);
     #if defined(QVGA)
-    cam_conf.format = CAMERA_QVGA;
+    cam_conf.format = PI_CAMERA_QVGA;
     #else
-    cam_conf.format = CAMERA_QQVGA;
+    cam_conf.format = PI_CAMERA_QQVGA;
     #endif  /* QVGA */
     pi_open_from_conf(device, &cam_conf);
     if (pi_camera_open(device))
@@ -181,7 +181,7 @@ void test_camera_with_lcd(void)
     buffer.data = imgBuff0 + CAMERA_WIDTH * 2 + 2;
     buffer.stride = 4;
 
-    // WIth Himax, propertly configure the buffer to skip boarder pixels
+    // With Himax, propertly configure the buffer to skip boarder pixels
     pi_buffer_init(&buffer, PI_BUFFER_TYPE_L2, imgBuff0 + CAMERA_WIDTH * 2 + 2);
     pi_buffer_set_stride(&buffer, 4);
     #else
@@ -194,12 +194,12 @@ void test_camera_with_lcd(void)
     while (1)
     {
         #if defined(ASYNC)
-        pi_camera_control(&cam, CAMERA_CMD_STOP, 0);
+        pi_camera_control(&cam, PI_CAMERA_CMD_STOP, 0);
         PRINTF("Camera stop.\n");
         pi_task_callback(&task, cam_handler, NULL);
         pi_camera_capture_async(&cam, imgBuff0, CAMERA_WIDTH * CAMERA_HEIGHT, &task);
         PRINTF("Image capture.\n");
-        pi_camera_control(&cam, CAMERA_CMD_START, 0);
+        pi_camera_control(&cam, PI_CAMERA_CMD_START, 0);
         PRINTF("Camera start.\n");
         pi_task_wait_on(&task);
         #else

--- a/rtos/pmsis/pmsis_bsp/examples/ili9341_with_himax/test.c
+++ b/rtos/pmsis/pmsis_bsp/examples/ili9341_with_himax/test.c
@@ -44,12 +44,12 @@ static void cam_handler(void *arg);
 
 static void cam_handler(void *arg)
 {
-  camera_control(&device, CAMERA_CMD_STOP, 0);
+  pi_camera_control(&device, PI_CAMERA_CMD_STOP, 0);
 
 #ifdef USE_BRIDGE
   rt_bridge_fb_update(fb, (unsigned int)imgBuff0, 0, 0, CAM_WIDTH, CAM_HEIGHT, NULL);
-  camera_capture_async(&device, imgBuff0, CAM_WIDTH*CAM_HEIGHT, pi_task_callback(&task, cam_handler, NULL));
-  camera_control(&device, CAMERA_CMD_START, 0);
+  pi_camera_capture_async(&device, imgBuff0, CAM_WIDTH*CAM_HEIGHT, pi_task_callback(&task, cam_handler, NULL));
+  pi_camera_control(&device, PI_CAMERA_CMD_START, 0);
 
 #else
   #if 1
@@ -64,8 +64,8 @@ static void cam_handler(void *arg)
 
 static void lcd_handler(void *arg)
 {
-  camera_control(&device, CAMERA_CMD_START, 0);
-  camera_capture_async(&device, imgBuff0, CAM_WIDTH*CAM_HEIGHT, pi_task_callback(&task, cam_handler, NULL));
+  pi_camera_control(&device, PI_CAMERA_CMD_START, 0);
+  pi_camera_capture_async(&device, imgBuff0, CAM_WIDTH*CAM_HEIGHT, pi_task_callback(&task, cam_handler, NULL));
 
 }
 
@@ -86,13 +86,13 @@ static int open_bridge()
 static int open_display(struct pi_device *device)
 {
 #ifndef USE_BRIDGE
-  struct ili9341_conf ili_conf;
+  struct pi_ili9341_conf ili_conf;
 
-  ili9341_conf_init(&ili_conf);
+  pi_ili9341_conf_init(&ili_conf);
 
   pi_open_from_conf(device, &ili_conf);
 
-  if (display_open(device))
+  if (pi_display_open(device))
     return -1;
 
   //if (display_ioctl(device, ILI_IOCTL_ORIENTATION, ILI_ORIENTATION_270))
@@ -112,16 +112,16 @@ static int open_display(struct pi_device *device)
 
 static int open_camera_himax(struct pi_device *device)
 {
-  struct himax_conf cam_conf;
+  struct pi_himax_conf cam_conf;
 
-  himax_conf_init(&cam_conf);
+  pi_himax_conf_init(&cam_conf);
 
 #ifdef QVGA
-  cam_conf.format = CAMERA_QVGA;
+  cam_conf.format = PI_CAMERA_QVGA;
 #endif
 
   pi_open_from_conf(device, &cam_conf);
-  if (camera_open(device))
+  if (pi_camera_open(device))
     return -1;
 
   return 0;
@@ -135,25 +135,25 @@ static int open_camera_himax(struct pi_device *device)
 
 static int open_camera_mt9v034(struct pi_device *device)
 {
-  struct mt9v034_conf cam_conf;
+  struct pi_mt9v034_conf cam_conf;
 
-  mt9v034_conf_init(&cam_conf);
+  pi_mt9v034_conf_init(&cam_conf);
 
 #ifdef QVGA
-  cam_conf.format = CAMERA_QVGA;
+  cam_conf.format = PI_CAMERA_QVGA;
 #endif
 #ifdef QQVGA
   cam_conf.format = CAMERA_QQVGA;
 #endif
 
   pi_open_from_conf(device, &cam_conf);
-  if (camera_open(device))
+  if (pi_camera_open(device))
     return -1;
 
   uint16_t val = MT9V034_BLACK_LEVEL_AUTO;
-  camera_reg_set(device, MT9V034_BLACK_LEVEL_CTRL, (uint8_t *) &val);
+  pi_camera_reg_set(device, MT9V034_BLACK_LEVEL_CTRL, (uint8_t *) &val);
   val = MT9V034_AEC_ENABLE_A|MT9V034_AGC_ENABLE_A;
-  camera_reg_set(device, MT9V034_AEC_AGC_ENABLE, (uint8_t *) &val);
+  pi_camera_reg_set(device, MT9V034_AEC_AGC_ENABLE, (uint8_t *) &val);
 
 
   return 0;
@@ -214,16 +214,16 @@ void test_ili9341_with_himax(void)
   while (1)
   {
       #if (ASYNC)
-      camera_control(&device, CAMERA_CMD_STOP, 0);
-      camera_capture_async(&device, imgBuff0, CAM_WIDTH*CAM_HEIGHT, pi_task_callback(&task, cam_handler, &device));
-      camera_control(&device, CAMERA_CMD_START, 0);
+      pi_camera_control(&device, PI_CAMERA_CMD_STOP, 0);
+      pi_camera_capture_async(&device, imgBuff0, CAM_WIDTH*CAM_HEIGHT, pi_task_callback(&task, cam_handler, &device));
+      pi_camera_control(&device, PI_CAMERA_CMD_START, 0);
       pi_task_wait_on(&task);
       #else
       printf("Camera start.\n");
-      camera_control(&device, CAMERA_CMD_START, 0);
-      camera_capture(&device, imgBuff0, CAM_WIDTH*CAM_HEIGHT);
+      pi_camera_control(&device, PI_CAMERA_CMD_START, 0);
+      pi_camera_capture(&device, imgBuff0, CAM_WIDTH*CAM_HEIGHT);
       printf("Camera image captured.\n");
-      camera_control(&device, CAMERA_CMD_STOP, 0);
+      pi_camera_control(&device, PI_CAMERA_CMD_STOP, 0);
       printf("Camera stop.\n");
       //pmsis_exit(0);
       #endif

--- a/rtos/pmsis/pmsis_bsp/examples/nina_b112_example/ImgIO.c
+++ b/rtos/pmsis/pmsis_bsp/examples/nina_b112_example/ImgIO.c
@@ -234,7 +234,6 @@ static void WritePPMHeader(int FD, unsigned int W, unsigned int H)
   }
 int WriteImageToFile(char *ImageName, unsigned int W, unsigned int H, unsigned char *OutBuffer)
 {
-	#define CHUNK_NUM 10
 	int File = BRIDGE_Open(ImageName, O_RDWR | O_CREAT, S_IRWXU, NULL);
 	int ret = 0;
 	WritePPMHeader(File,W,H);

--- a/rtos/pmsis/pmsis_bsp/tests/camera/simple/test.c
+++ b/rtos/pmsis/pmsis_bsp/tests/camera/simple/test.c
@@ -41,14 +41,14 @@ static int open_camera(struct pi_device *device)
   himax_conf_init(&cam_conf);
 #elif defined(CONFIG_MT9V034)
   printf("Opening mt9v034 camera\n");
-  struct mt9v034_conf cam_conf;
-  mt9v034_conf_init(&cam_conf);
+  struct pi_mt9v034_conf cam_conf;
+  pi_mt9v034_conf_init(&cam_conf);
 #endif
 
-  cam_conf.format = CAMERA_QVGA;
+  cam_conf.format = PI_CAMERA_QVGA;
 
   pi_open_from_conf(device, &cam_conf);
-  if (camera_open(device))
+  if (pi_camera_open(device))
     return -1;
 
   return 0;
@@ -73,13 +73,13 @@ static int test_entry()
   buff[1] = pmsis_l2_malloc(WIDTH*HEIGHT);
   if (buff[1] == NULL) goto error;
 
-  camera_capture_async(&camera, buff[0], WIDTH*HEIGHT, pi_task_block(&task));
+  pi_camera_capture_async(&camera, buff[0], WIDTH*HEIGHT, pi_task_block(&task));
 
-  camera_control(&camera, CAMERA_CMD_START, 0);
+  pi_camera_control(&camera, PI_CAMERA_CMD_START, 0);
 
   pi_task_wait_on(&task);
 
-  camera_control(&camera, CAMERA_CMD_STOP, 0);
+  pi_camera_control(&camera, PI_CAMERA_CMD_STOP, 0);
 
   for (int j=0; j<1; j++)
   {
@@ -98,7 +98,7 @@ static int test_entry()
     }
   }
 
-  camera_close(&camera);
+  pi_camera_close(&camera);
   printf("Test success\n");
 
   return 0;

--- a/rtos/pmsis/pmsis_bsp/tests/camera/start_stop/test.c
+++ b/rtos/pmsis/pmsis_bsp/tests/camera/start_stop/test.c
@@ -55,18 +55,18 @@ static int test_entry()
 
 #if defined(CONFIG_MT9V034)
   printf("Opening mt9v034 camera\n");
-  struct mt9v034_conf cam_conf;
-  mt9v034_conf_init(&cam_conf);
+  struct pi_mt9v034_conf cam_conf;
+  pi_mt9v034_conf_init(&cam_conf);
 #else
   printf("Opening Himax camera\n");
   struct himax_conf cam_conf;
   himax_conf_init(&cam_conf);
 #endif
 
-  cam_conf.format = CAMERA_QVGA;
+  cam_conf.format = PI_CAMERA_QVGA;
 
   pi_open_from_conf(&device, &cam_conf);
-  if (camera_open(&device))
+  if (pi_camera_open(&device))
     return -1;
 
   for (int i=0; i<get_nb_buffers(); i++)
@@ -82,11 +82,11 @@ static int test_entry()
   {
     pi_task_t task;
 
-    camera_capture_async(&device, buff[i], WIDTH*HEIGHT, pi_task_block(&task));
-    camera_control(&device, CAMERA_CMD_START, 0);
+    pi_camera_capture_async(&device, buff[i], WIDTH*HEIGHT, pi_task_block(&task));
+    pi_camera_control(&device, PI_CAMERA_CMD_START, 0);
 
     pi_task_wait_on(&task);
-    camera_control(&device, CAMERA_CMD_STOP, 0);
+    pi_camera_control(&device, PI_CAMERA_CMD_STOP, 0);
 
     // Now wait some time to start capturing in the middle of the next frame
     pi_time_wait_us((i + 1) * 5000);
@@ -107,7 +107,7 @@ static int test_entry()
     }
   }
 
-  camera_close(&device);
+  pi_camera_close(&device);
   printf("Test success\n");
 
 


### PR DESCRIPTION
* Add pi_ / PI_ prefix where appropriate to fix build of applications and examples;
* Drop unused CHUNK_NUM macro;