### PR TITLE
Fixed missing 'requests' dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyelftools==0.24
 prettytable==0.7.2
 configparser
 argcomplete
+requests


### PR DESCRIPTION
As mentioned in #174

Fresh conda envs lack `requests` by default.