### PR TITLE
gvsoc: Do not error out on -Wnonnull

### DIFF
--- a/gvsoc/gvsoc/engine/Makefile
+++ b/gvsoc/gvsoc/engine/Makefile
@@ -12,6 +12,7 @@ V = @
 endif
 
 CFLAGS +=  -MMD -MP -O2 -g -fpic -Isrc -std=c++11 -Werror -Wall -I$(INSTALL_DIR)/include
+CFLAGS += -Wno-nonnull
 
 LDFLAGS += -O2 -g -Werror -Wall -lz -L$(INSTALL_DIR)/lib -Wl,--whole-archive -ljson -Wl,--no-whole-archive
 


### PR DESCRIPTION
The gcc 11.2 version seemst to be more aggresive in nonnull checks.

Fixes: #272
