### PR TITLE
pmsis_tools_frame_streamer.cpp: Use cv::IMREAD_GRAYSCALE

### DIFF
--- a/tools/gap_tools/python/pmsis_tools_frame_streamer.cpp
+++ b/tools/gap_tools/python/pmsis_tools_frame_streamer.cpp
@@ -261,7 +261,7 @@ void Frame_stream::handle_req(Transport_req_t *req)
 
       std::vector<uint8_t> jpeg_image(&jpeg_buffer[0], &jpeg_buffer[jpeg_buffer_size]);
       InputArray input_array(jpeg_image);
-      Mat image = imdecode(input_array, CV_LOAD_IMAGE_GRAYSCALE);
+      Mat image = imdecode(input_array, cv::IMREAD_GRAYSCALE);
 
       memcpy(buffer, image.data, this->width*this->height);
       delete jpeg_buffer;


### PR DESCRIPTION
This is the way with latest OpenCV:
  https://docs.opencv.org/master/d4/da8/group__imgcodecs.html

Fixes #274
