### PR TITLE
DMA merge ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# the MAGICK_ROOT variable can be used to pass an alternative installation
+# prefix for the GraphicsMagick library. 
+ifdef MAGICK_ROOT
+export MAGICK_ROOT := $(realpath $(MAGICK_ROOT))
+endif
+
 ifeq ($(TARGET_CHIP), GAP9)
 use_old_build = 1
 endif

--- a/gap8/gvsoc/dpi-models/Makefile
+++ b/gap8/gvsoc/dpi-models/Makefile
@@ -1,7 +1,7 @@
 VSIM_DETECTED_PATH=$(dir $(shell which vsim))
 BUILD_DIR ?= build
 
-CFLAGS += -std=gnu++11 -MMD -MP -O3 -g
+CFLAGS += -std=c++11 -MMD -MP -O3 -g
 
 CFLAGS += -I$(INSTALL_DIR)/include -fPIC
 LDFLAGS += -L$(INSTALL_DIR)/lib -fPIC -shared -O3 -g -ljson

--- a/gap8/gvsoc/dpi-models/models/camera/Makefile
+++ b/gap8/gvsoc/dpi-models/models/camera/Makefile
@@ -2,11 +2,21 @@ DPI_MODELS += camera
 
 camera_SRCS = camera/camera.cpp
 
-MAGICK=$(shell pkg-config --exists GraphicsMagick --atleast-version=1.3.23 || echo FAILED)
+MAGICK_PKG_CFG_CMD := pkg-config
+ifdef MAGICK_ROOT
+# MAGICK_ROOT can be set to specify the root directory (containing e.g. /lib/,
+# /include/ etc) where GraphicsMagick was installed from source
+MAGICK_PKG_CFG_PATH := $(MAGICK_ROOT)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+camera_CFLAGS += -Wl,-rpath=$(MAGICK_ROOT)/lib -I$(MAGICK_ROOT)/include/GraphicsMagick
+MAGICK_PKG_CFG_CMD := PKG_CONFIG_PATH=$(MAGICK_PKG_CFG_PATH) pkg-config
+endif
+
+MAGICK=$(shell $(MAGICK_PKG_CFG_CMD)  --exists GraphicsMagick --atleast-version=1.3.23 || echo FAILED)
+
 
 ifeq '$(MAGICK)' ''
-camera_CFLAGS += $(shell pkg-config GraphicsMagick --cflags)
+camera_CFLAGS += $(shell $(MAGICK_PKG_CFG_CMD) GraphicsMagick++ --cflags)
 camera_CFLAGS += -D__MAGICK__
-camera_LDFLAGS += -lGraphicsMagick++ -lGraphicsMagick
+camera_LDFLAGS := $(shell $(MAGICK_PKG_CFG_CMD) GraphicsMagick++ --libs)
 #LDFLAGS += $(shell Magick++-config --ldflags)
 endif

--- a/gap8/rtos/pulp/pulp-os/include/pmsis/implem/dma.h
+++ b/gap8/rtos/pulp/pulp-os/include/pmsis/implem/dma.h
@@ -47,7 +47,7 @@ static inline void __cl_dma_memcpy(unsigned int ext, unsigned int loc, unsigned 
 
   eu_mutex_lock_from_id(0);
 
-  int id = -1;
+  int id = copy->id;
   if (!merge) id = plp_dma_counter_alloc();
   unsigned int cmd = plp_dma_getCmd(dir, size, PLP_DMA_1D, PLP_DMA_TRIG_EVT, PLP_DMA_NO_TRIG_IRQ, PLP_DMA_SHARED);
   // Prevent the compiler from pushing the transfer before all previous
@@ -74,7 +74,7 @@ static inline void __cl_dma_memcpy_2d(unsigned int ext, unsigned int loc, unsign
 
   eu_mutex_lock_from_id(0);
 
-  int id = -1;
+  int id = copy->id;
   if (!merge) id = plp_dma_counter_alloc();
 
   {
@@ -101,7 +101,7 @@ static inline void __cl_dma_copy(uint32_t ext, uint32_t loc, uint32_t len,
                                  pi_cl_dma_dir_e dir, uint8_t merge, uint32_t dma_cmd,
                                  pi_cl_dma_cmd_t *cmd)
 {
-    int32_t tid = -1;
+    int32_t tid = cmd->id;
     uint32_t iter_length = (len < length) ? len : length;
 
     cmd->loc_addr = loc;
@@ -144,7 +144,7 @@ static inline void __cl_dma_memcpy(unsigned int ext, unsigned int loc, unsigned 
     uint32_t max_len = (1 << 15);
     if (size < max_len)
     {
-        int id = -1;
+        int id = copy->id;
         if (!merge) id = plp_dma_counter_alloc();
         unsigned int cmd = plp_dma_getCmd(dir, size, PLP_DMA_1D, PLP_DMA_TRIG_EVT, PLP_DMA_NO_TRIG_IRQ, PLP_DMA_SHARED);
         // Prevent the compiler from pushing the transfer before all previous
@@ -189,7 +189,7 @@ static inline void __cl_dma_memcpy_2d(unsigned int ext, unsigned int loc, unsign
 
     int irq = rt_irq_disable();
 
-    int id = -1;
+    int id = copy->id;
 
     if (stride < (1<<15))
     {
@@ -256,6 +256,7 @@ static inline void __cl_dma_wait(pi_cl_dma_cmd_t *copy)
   plp_dma_counter_free(counter);
 
   eu_mutex_unlock_from_id(0);
+  copy->id = -1;
   
 #ifdef __RT_USE_PROFILE
   gv_vcd_dump_trace(trace, 1);
@@ -283,6 +284,7 @@ static inline void __cl_dma_wait(pi_cl_dma_cmd_t *copy)
     plp_dma_counter_free(copy->id);
 
     rt_irq_restore(irq);
+    copy->id = -1;
   }
   else
   {

--- a/gap8/rtos/pulp/pulp-os/include/rt/rt_dma.h
+++ b/gap8/rtos/pulp/pulp-os/include/rt/rt_dma.h
@@ -158,7 +158,7 @@ static inline void rt_dma_memcpy(unsigned int ext, unsigned int loc, unsigned sh
   gv_vcd_dump_trace(trace, 4);
 #endif
 
-  int id = -1;
+  int id = copy->id;
 #if MCHAN_VERSION >= 7
   eu_mutex_lock_from_id(0);
 #endif
@@ -186,7 +186,7 @@ static inline void rt_dma_memcpy_2d(unsigned int ext, unsigned int loc, unsigned
   gv_vcd_dump_trace(trace, 4);
 #endif
 
-  int id = -1;
+  int id = copy->id;
 #if MCHAN_VERSION >= 7
   eu_mutex_lock_from_id(0);
 #endif

--- a/rtos/freeRTOS/vendors/gwt/gap8/pmsis/include/pmsis/implem/cluster/dma/cl_dma.h
+++ b/rtos/freeRTOS/vendors/gwt/gap8/pmsis/include/pmsis/implem/cluster/dma/cl_dma.h
@@ -72,7 +72,7 @@ static inline void __pi_cl_dma_copy(uint32_t ext, uint32_t loc, uint32_t len,
                                     uint8_t dir, uint8_t merge, uint32_t dma_cmd,
                                     pi_cl_dma_cmd_t *cmd)
 {
-    int32_t tid = -1;
+    int32_t tid = cmd->tid;
     uint32_t iter_length = (len < length) ? len : length;
 
     cmd->loc = loc;
@@ -118,7 +118,7 @@ static inline void __pi_cl_dma_1d_copy(uint32_t ext, uint32_t loc, uint32_t len,
     if (len < max_len)
     {
         iter_length = len;
-        cmd->tid = -1;
+        cmd->tid = cmd->tid;
         if (!merge)
         {
             cmd->tid = hal_cl_dma_tid_get();
@@ -149,7 +149,7 @@ static inline void __pi_cl_dma_2d_copy(uint32_t ext, uint32_t loc, uint32_t len,
                                        uint8_t dir, uint8_t merge, pi_cl_dma_cmd_t *cmd)
 {
     uint32_t irq = disable_irq();
-    int32_t tid = -1;
+    int32_t tid = cmd->tid;
     if (stride < (1 << 15))
     {
         if (!merge)

--- a/rtos/pmsis/pmsis_api/include/pmsis/cluster/dma/cl_dma.h
+++ b/rtos/pmsis/pmsis_api/include/pmsis/cluster/dma/cl_dma.h
@@ -193,9 +193,9 @@ static inline void pi_cl_dma_wait(void *copy);
 /// @cond IMPLEM
 
 #define CL_DMA_COMMON                           \
+    int id;                                     \
     uint32_t ext;                               \
     uint32_t loc;                               \
-    uint32_t id;                                \
     uint32_t size;                              \
     pi_cl_dma_dir_e dir;                        \
     uint8_t merge;

--- a/rtos/pulp/pulpos-2/include/pos/implem/dma.h
+++ b/rtos/pulp/pulpos-2/include/pos/implem/dma.h
@@ -44,6 +44,7 @@ static inline void __cl_dma_wait_safe(pi_cl_dma_cmd_t *copy)
   }
 
   plp_dma_counter_free(counter);
+  copy->id = -1;
 }
 
 
@@ -62,6 +63,7 @@ static inline void __cl_dma_wait(pi_cl_dma_cmd_t *copy)
   plp_dma_counter_free(counter);
 
   eu_mutex_unlock_from_id(0);
+  copy->id = -1;
 }
 
 
@@ -69,7 +71,7 @@ static inline void __cl_dma_memcpy(unsigned int ext, unsigned int loc, unsigned 
 {
   eu_mutex_lock_from_id(0);
   
-  int id = -1;
+  int id = copy->id;
   if (!merge) id = plp_dma_counter_alloc();
   unsigned int cmd = plp_dma_getCmd(dir, size, PLP_DMA_1D, PLP_DMA_TRIG_EVT, PLP_DMA_NO_TRIG_IRQ, PLP_DMA_SHARED);
   // Prevent the compiler from pushing the transfer before all previous
@@ -84,7 +86,7 @@ static inline void __cl_dma_memcpy(unsigned int ext, unsigned int loc, unsigned 
 
 static inline void __cl_dma_memcpy_safe(unsigned int ext, unsigned int loc, unsigned int size, pi_cl_dma_dir_e dir, int merge, pi_cl_dma_cmd_t *copy)
 {
-  int id = -1;
+  int id = copy->id;
   if (!merge) id = plp_dma_counter_alloc();
   unsigned int cmd = plp_dma_getCmd(dir, size, PLP_DMA_1D, PLP_DMA_TRIG_EVT, PLP_DMA_NO_TRIG_IRQ, PLP_DMA_SHARED);
   // Prevent the compiler from pushing the transfer before all previous
@@ -100,7 +102,7 @@ static inline void __cl_dma_memcpy_irq(unsigned int ext, unsigned int loc, unsig
 {
   eu_mutex_lock_from_id(0);
   
-  int id = -1;
+  int id = copy->id;
   if (!merge) id = plp_dma_counter_alloc();
   unsigned int cmd = plp_dma_getCmd(dir, size, PLP_DMA_1D, PLP_DMA_NO_TRIG_EVT, PLP_DMA_TRIG_IRQ, PLP_DMA_SHARED);
   // Prevent the compiler from pushing the transfer before all previous
@@ -131,7 +133,7 @@ static inline void __cl_dma_memcpy_2d(unsigned int ext, unsigned int loc, unsign
 {
   eu_mutex_lock_from_id(0);
   
-  int id = -1;
+  int id = copy->id;
   if (!merge) id = plp_dma_counter_alloc();
 
   {


### PR DESCRIPTION
This PR addresses an inconsistent DMA ID in case the `merge` flag is used. The previous implementation would reset the `copy.id` to -1 in case the `copy.merge` flag is set, this PR changes it to keep the passed ID.

This PR also includes a minor fix for machines with inconsistent GraphicsMagick versions, allowing to use a custom install linked with `MAGICK_ROOT`.