### PR TITLE
Strip "open" command of leading and trailing spaces in project generation

### DIFF
--- a/tools/nntool/interpreter/commands/gen_project.py
+++ b/tools/nntool/interpreter/commands/gen_project.py
@@ -63,7 +63,7 @@ def parse_last_open(history):
     args = None
     for command in reversed(history):
         if command.startswith('open'):
-            args = OpenCommand.parser_open.parse_args(command.split(' ')[1:])
+            args = OpenCommand.parser_open.parse_args(command.strip().split(' ')[1:])
             break
     return args
 


### PR DESCRIPTION
Since the "open" command is split on whitespaces to identify arguments, a trailing whitespace will result in an unrecognized - empty - argument to the "open" command in the project generation.
Trailing whitespaces given to the "open" command can originate from auto completion on the to be opened filename.

```
(NNT cnn.tflite 0) gen_project .
Usage: open [-h] [--orgmodel_path INPUT_GRAPH or STATE_FILE] [-n]
            [--no_fold_batchnorm] [--use_hard_tanh] [--use_hard_sigmoid]
            [--use_lut_tanh] [--use_lut_sigmoid] [-q]
            [--no_remove_quantize_ops] [--no_rescale_perchannel]
            [--subs [KEY=VALUE [...]]]
            [--input_shapes [KEY=ARRAY_VALUE [...]]]
            [--fixed_inputs [KEY=ARRAY_VALUE [...]]] [--out_ranges OUT_RANGES]
            INPUT_GRAPH or STATE_FILE
Error: unrecognized arguments: 
```

This pull request fixes this by first removing leading and trailing whitespaces using the built-in strip method, before splitting.