### PR TITLE
Fix JPEG encoding undefined reference

### DIFF
--- a/libs/gap_lib/jpeg/cluster.c
+++ b/libs/gap_lib/jpeg/cluster.c
@@ -33,7 +33,7 @@
 #if defined(__GAP9__)
     #define eu_evt_maskWaitAndClr(x) (hal_cl_eu_event_mask_wait_and_clear(x))
 #else
-    #define eu_evt_maskWaitAndClr(x) (hal_cl_eu_event_mask_wait_clear(x))
+    #define eu_evt_maskWaitAndClr(x) (hal_cl_eu_evt_mask_wait_clear(x))
 #endif
 #else
     #define RT_USER_EVENT 6


### PR DESCRIPTION
When trying to compile [this WiFi image streaming example](https://github.com/bitcraze/aideck-gap8-examples/tree/master/examples/other/wifi-img-streamer) with JPEG encoding:

`/home/gemenerik/gap_sdk/libs/gap_lib/jpeg/cluster.c:138: undefined reference to "hal_cl_eu_event_mask_wait_clear"`